### PR TITLE
Ability to define a table name per xQuery module

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ by adding `defql` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:defql, "~> 0.1.0"}]
+  [{:defql, "~> 0.1.1"}]
 end
 ```
 
@@ -68,6 +68,20 @@ UserQuery.update([name: "Other"],[id: "2"]) # => {:ok, [%{...}]}
 UserQuery.delete(id: "2") # => {:ok, [%{...}]}
 
 UserQuery.get_by_name("Ela", 4) # => {:ok, [%{...}, %{...}]}
+```
+
+We can define common table for the whole xQuery module.
+_As well as specify certain table for certain function (as shown above)._
+
+```elixir
+defmodule UserQuery do
+  use Defql, table: :users
+
+  defselect get(conds)
+  definsert add(params)
+  defupdate update(params, conds)
+  defdelete delete(conds)
+end
 ```
 
 `%{...}` It's a hash with user properties straight from database.

--- a/lib/defql.ex
+++ b/lib/defql.ex
@@ -74,13 +74,21 @@ defmodule Defql do
   """
 
   @doc false
-  defmacro __using__(_opts) do
+  defmacro __using__(opts) do
     quote do
+      Module.put_attribute(__MODULE__, :table, Keyword.get(unquote(opts), :table))
+      
+      def resolve_table(opts) do
+        Keyword.get(opts, :table) ||
+        @table ||
+        raise(ArgumentError, "table wasn't specified'")
+      end
+
       import Defql.Macros.Defquery
       import Defql.Macros.Definsert
       import Defql.Macros.Defdelete
       import Defql.Macros.Defupdate
       import Defql.Macros.Defselect
-    end
+    end      
   end
 end

--- a/lib/defql.ex
+++ b/lib/defql.ex
@@ -80,7 +80,7 @@ defmodule Defql do
                            :table,
                            Keyword.get(unquote(opts),
                            :table))
-      
+
       def resolve_table(opts) do
         Keyword.get(opts, :table) ||
         @table ||
@@ -92,6 +92,6 @@ defmodule Defql do
       import Defql.Macros.Defdelete
       import Defql.Macros.Defupdate
       import Defql.Macros.Defselect
-    end      
+    end
   end
 end

--- a/lib/defql.ex
+++ b/lib/defql.ex
@@ -76,7 +76,10 @@ defmodule Defql do
   @doc false
   defmacro __using__(opts) do
     quote do
-      Module.put_attribute(__MODULE__, :table, Keyword.get(unquote(opts), :table))
+      Module.put_attribute(__MODULE__,
+                           :table,
+                           Keyword.get(unquote(opts),
+                           :table))
       
       def resolve_table(opts) do
         Keyword.get(opts, :table) ||

--- a/lib/defql/macros/defdelete.ex
+++ b/lib/defql/macros/defdelete.ex
@@ -4,7 +4,9 @@ defmodule Defql.Macros.Defdelete do
   alias Defql.Connection
 
   @doc false
-  defmacro defdelete({name, _, params}, opts \\ []) when is_atom(name) and is_list(params) and length(params) == 1 do
+  defmacro defdelete(_name_params, opts \\ [])
+  @doc false
+  defmacro defdelete({name, _, params}, opts) when is_atom(name) and is_list(params) and length(params) == 1 do
     [first | _] = params
     quote do
       def unquote(name)(unquote_splicing(params)) do

--- a/lib/defql/macros/defdelete.ex
+++ b/lib/defql/macros/defdelete.ex
@@ -4,12 +4,12 @@ defmodule Defql.Macros.Defdelete do
   alias Defql.Connection
 
   @doc false
-  defmacro defdelete({name, _, params}, [table: table]) when is_atom(name) and is_list(params) and length(params) == 1 and is_atom(table) do
+  defmacro defdelete({name, _, params}, opts \\ []) when is_atom(name) and is_list(params) and length(params) == 1 do
     [first | _] = params
     quote do
       def unquote(name)(unquote_splicing(params)) do
         Connection.delete(
-                            unquote(table),
+                            resolve_table(unquote(opts)),
                             unquote(first)
                           )
       end

--- a/lib/defql/macros/definsert.ex
+++ b/lib/defql/macros/definsert.ex
@@ -4,12 +4,12 @@ defmodule Defql.Macros.Definsert do
   alias Defql.Connection
 
   @doc false
-  defmacro definsert({name, _, params}, [table: table]) when is_atom(name) and is_list(params) and length(params) == 1 and is_atom(table) do
+  defmacro definsert({name, _, params}, opts \\ []) when is_atom(name) and is_list(params) and length(params) == 1 do
     [first | _] = params
     quote do
       def unquote(name)(unquote_splicing(params)) do
         Connection.insert(
-                            unquote(table),
+                            resolve_table(unquote(opts)),
                             unquote(first)
                           )
       end

--- a/lib/defql/macros/definsert.ex
+++ b/lib/defql/macros/definsert.ex
@@ -4,7 +4,9 @@ defmodule Defql.Macros.Definsert do
   alias Defql.Connection
 
   @doc false
-  defmacro definsert({name, _, params}, opts \\ []) when is_atom(name) and is_list(params) and length(params) == 1 do
+  defmacro definsert(_name_params, opts \\ [])
+  @doc false
+  defmacro definsert({name, _, params}, opts) when is_atom(name) and is_list(params) and length(params) == 1 do
     [first | _] = params
     quote do
       def unquote(name)(unquote_splicing(params)) do

--- a/lib/defql/macros/defselect.ex
+++ b/lib/defql/macros/defselect.ex
@@ -4,27 +4,29 @@ defmodule Defql.Macros.Defselect do
   alias Defql.Connection
 
   @doc false
-  defmacro defselect({name, _, params}, [table: table]) when is_atom(name) and is_list(params) and length(params) == 1 and is_atom(table) do
+  defmacro defselect(_name_params, _opts \\ [])
+  @doc false
+  defmacro defselect({name, _, params}, [columns: columns] = opts) when is_atom(name) and is_list(params) and length(params) == 1 and is_list(columns) do
     [first | _] = params
     quote do
       def unquote(name)(unquote_splicing(params)) do
         Connection.select(
-                            unquote(table),
-                            unquote(first)
+                            resolve_table(unquote(opts)),
+                            unquote(first),
+                            unquote(columns)
                           )
       end
     end
   end
 
   @doc false
-  defmacro defselect({name, _, params}, [table: table, columns: columns]) when is_atom(name) and is_list(params) and length(params) == 1 and is_atom(table) and is_list(columns) do
+  defmacro defselect({name, _, params}, opts) when is_atom(name) and is_list(params) and length(params) == 1 do
     [first | _] = params
     quote do
       def unquote(name)(unquote_splicing(params)) do
         Connection.select(
-                            unquote(table),
-                            unquote(first),
-                            unquote(columns)
+                            resolve_table(unquote(opts)),
+                            unquote(first)
                           )
       end
     end

--- a/lib/defql/macros/defupdate.ex
+++ b/lib/defql/macros/defupdate.ex
@@ -4,12 +4,12 @@ defmodule Defql.Macros.Defupdate do
   alias Defql.Connection
 
   @doc false
-  defmacro defupdate({name, _, params}, [table: table]) when is_atom(name) and is_list(params) and length(params) == 2 and is_atom(table) do
+  defmacro defupdate({name, _, params}, opts \\ []) when is_atom(name) and is_list(params) and length(params) == 2 do
     [first, second | _] = params
     quote do
       def unquote(name)(unquote_splicing(params)) do
         Connection.update(
-                            unquote(table),
+                            resolve_table(unquote(opts)),
                             unquote(first),
                             unquote(second)
                           )

--- a/lib/defql/macros/defupdate.ex
+++ b/lib/defql/macros/defupdate.ex
@@ -4,7 +4,9 @@ defmodule Defql.Macros.Defupdate do
   alias Defql.Connection
 
   @doc false
-  defmacro defupdate({name, _, params}, opts \\ []) when is_atom(name) and is_list(params) and length(params) == 2 do
+  defmacro defupdate(_name_params, opts \\ [])
+  @doc false
+  defmacro defupdate({name, _, params}, opts) when is_atom(name) and is_list(params) and length(params) == 2 do
     [first, second | _] = params
     quote do
       def unquote(name)(unquote_splicing(params)) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Defql.Mixfile do
   def project do
     [
       app: :defql,
-      version: "0.1.0",
+      version: "0.1.1",
       elixir: "~> 1.3",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,

--- a/test/defql/defql_test.exs
+++ b/test/defql/defql_test.exs
@@ -1,0 +1,13 @@
+defmodule Test.Defql.Defql do
+  use ExUnit.Case
+
+  defmodule TestQuery do
+    use Defql, table: :test_table_name
+
+    def get_table, do: @table
+  end
+
+  test "allows to define and store a table name in an attribute" do
+    assert TestQuery.get_table == :test_table_name
+  end
+end

--- a/test/defql/macros/defdelete_test.exs
+++ b/test/defql/macros/defdelete_test.exs
@@ -1,8 +1,9 @@
 defmodule Test.Defql.Macros.Defdelete do
   use ExUnit.Case
-  import Defql.Macros.Defdelete
+  use Defql, table: :common_table
 
   defdelete delete(params), table: :test
+  defdelete remove(params)
 
   test "defdelete lists" do
     {status, result} = delete(a: 1)
@@ -18,5 +19,10 @@ defmodule Test.Defql.Macros.Defdelete do
     assert status == :ok
     assert result.query == "DELETE test"
     assert result.params == %{a: 1}
+  end
+
+  test "takes a table name from Defql attribute (if it was specified)" do
+    {_status, result} = remove(%{a: 1})
+    assert result.query == "DELETE common_table"
   end
 end

--- a/test/defql/macros/definsert_test.exs
+++ b/test/defql/macros/definsert_test.exs
@@ -1,8 +1,9 @@
 defmodule Test.Defql.Macros.Definsert do
   use ExUnit.Case
-  import Defql.Macros.Definsert
+  use Defql, table: :common_table
 
   definsert insert(params), table: :test
+  definsert add(params)
 
   test "definsert lists" do
     {status, result} = insert(a: 1)
@@ -18,5 +19,10 @@ defmodule Test.Defql.Macros.Definsert do
     assert status == :ok
     assert result.query == "INSERT test"
     assert result.params == %{a: 1}
+  end
+
+  test "takes a table name from Defql attribute (if it was specified)" do
+    {_status, result} = add(%{a: 1})
+    assert result.query == "INSERT common_table"
   end
 end

--- a/test/defql/macros/defselect_test.exs
+++ b/test/defql/macros/defselect_test.exs
@@ -1,8 +1,9 @@
 defmodule Test.Defql.Macros.Defselect do
   use ExUnit.Case
-  import Defql.Macros.Defselect
+  use Defql, table: :common_table
 
   defselect select(params), table: :test
+  defselect get(params)
 
   test "defselect lists" do
     {status, result} = select(a: 1)
@@ -18,5 +19,10 @@ defmodule Test.Defql.Macros.Defselect do
     assert status == :ok
     assert result.query == "SELECT test"
     assert result.params == %{a: 1}
+  end
+  
+  test "takes a table name from Defql attribute (if it was specified)" do
+    {_status, result} = get(%{a: 1})
+    assert result.query == "SELECT common_table"
   end
 end

--- a/test/defql/macros/defupdate_test.exs
+++ b/test/defql/macros/defupdate_test.exs
@@ -1,8 +1,9 @@
 defmodule Test.Defql.Macros.Defupdate do
   use ExUnit.Case
-  import Defql.Macros.Defupdate
+  use Defql, table: :common_table
 
   defupdate update(params, conds), table: :test
+  defupdate edit(params, conds)
 
   test "defupdate lists" do
     {status, result} = update([a: 1], [b: 2])
@@ -34,5 +35,10 @@ defmodule Test.Defql.Macros.Defupdate do
     assert status == :ok
     assert result.query == "UPDATE test"
     assert result.params == [a: 1]
+  end
+
+  test "takes a table name from Defql attribute (if it was specified)" do
+    {_status, result} = edit(%{a: 1}, %{b: 2})
+    assert result.query == "UPDATE common_table"
   end
 end


### PR DESCRIPTION
Hi, here is my attempting to implement an ability to define table name per a whole xQuery module (Defql adopter).

Here is an example from updated README:

```elixir
defmodule UserQuery do
  use Defql, table: :users

  defselect get(conds)
  definsert add(params)
  defupdate update(params, conds)
  defdelete delete(conds)
end
```

Hope, you'll find time to check this out.